### PR TITLE
Suggestion: use "how to" in headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ See [CITATION](CITATION).
 
 <Summarise what's in this repository>
 
-## Reproducing figures and tables
+# How to reproduce figures and tables?
 
 <Instructions on how to use summary/derived data in the `results` directory to create figures and tables>
 
 <Specify precise steps, including any datasets that need to be downloaded and path variables that need to be set>
 
-## Reproducing full analysis
+# How to rerun the full analysis?
 
 <Instructions on how to (1) obtain raw data; (2) process it to create summary/derived data in the `results`>
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@
 
 See [CITATION](CITATION).
 
-# Contents overview
+## Contents overview
 
 <Summarise what's in this repository>
 
-# How to reproduce figures and tables
+## How to reproduce figures and tables
 
 <Instructions on how to use summary/derived data in the `results` directory to create figures and tables>
 
 <Specify precise steps, including any datasets that need to be downloaded and path variables that need to be set>
 
 
-# How to rerun the full analysis
+## How to rerun the full analysis
 
 ### Table 1
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       * [Fig. 2](#fig-2)
    * [Reproducing full analysis](#reproducing-full-analysis)
 
-## How to cite?
+## How to cite
 
 See [CITATION](CITATION).
 
@@ -21,14 +21,14 @@ See [CITATION](CITATION).
 
 <Summarise what's in this repository>
 
-# How to reproduce figures and tables?
+# How to reproduce figures and tables
 
 <Instructions on how to use summary/derived data in the `results` directory to create figures and tables>
 
 <Specify precise steps, including any datasets that need to be downloaded and path variables that need to be set>
 
 
-# How to rerun the full analysis?
+# How to rerun the full analysis
 
 ### Table 1
 


### PR DESCRIPTION
I propose the following changes:
 - "Reproducing figures and tables" replaced by "How to reproduce figures and tables?" and 
 - "Reproducing full analysis" replaced by "How to rerun the full analysis?". 

@nicholst, @schw4b: what do you think of this? 